### PR TITLE
Shoulder pitch

### DIFF
--- a/orne_or_manipulation/orne_or_manipulator_driver/src/orne_or_manipulator_driver.cpp
+++ b/orne_or_manipulation/orne_or_manipulator_driver/src/orne_or_manipulator_driver.cpp
@@ -339,7 +339,7 @@ class IMDriver : public hardware_interface::RobotHW
             deg100[i] = kondo_vector[i]->get_deg100();
             const int right_shoulder_pitch_id = 11; // temporary begin
             const int left_shoulder_pitch_id = 21;
-            if id[i] == right_shoulder_pitch_id || id[i] == left_shoulder_pitch_id {
+            if (id[i] == right_shoulder_pitch_id || id[i] == left_shoulder_pitch_id) {
                 deg100[i] *= 4.0;
             }                                       // temporary end
             kondo_vector[i]->set_pos(deg100[i]);

--- a/orne_or_manipulation/orne_or_manipulator_driver/src/orne_or_manipulator_driver.cpp
+++ b/orne_or_manipulation/orne_or_manipulator_driver/src/orne_or_manipulator_driver.cpp
@@ -337,6 +337,11 @@ class IMDriver : public hardware_interface::RobotHW
         for (int i=0; i<len; i++) {
             id[i] = kondo_vector[i]->get_id();
             deg100[i] = kondo_vector[i]->get_deg100();
+            const int right_shoulder_pitch_id = 11; // temporary begin
+            const int left_shoulder_pitch_id = 21;
+            if id[i] == right_shoulder_pitch_id || id[i] == left_shoulder_pitch_id {
+                deg100[i] *= 4.0;
+            }                                       // temporary end
             kondo_vector[i]->set_pos(deg100[i]);
         }
         if (!loopback)


### PR DESCRIPTION
肩のピッチ関節(id:11, 21)の回転量を強制的に4倍にする処理
場当たり的な処理なので，後で作り直すことが望ましい．